### PR TITLE
Retoques al simulador

### DIFF
--- a/src/main/java/es/jyago/hermes/simulator/SimulatedSmartDriver.java
+++ b/src/main/java/es/jyago/hermes/simulator/SimulatedSmartDriver.java
@@ -52,7 +52,7 @@ public class SimulatedSmartDriver extends TimerTask {
     private final Marker trackMarker;
     private int elapsedSeconds;
     private boolean locationChanged;
-    private final PublisherHC publisher;
+    private PublisherHC publisher;
     private List<LocationLogDetail> localLocationLogDetailList;
     private double speedRandomFactor;
 
@@ -321,13 +321,15 @@ public class SimulatedSmartDriver extends TimerTask {
                 ztreamySecondsCount = 0;
             } else {
                 SimulatorController.increaseZtreamyErrors();
-                LOG.log(Level.SEVERE, "sendEvery10SecondsIfLocationChanged() - Error SEND: Trama: {0} - Enviada a las: {1} - Errores: {2} / Total: {3}", new Object[]{Constants.dfISO8601.format(currentLocationLogDetail.getTimeLog()), Constants.dfISO8601.format(System.currentTimeMillis()), SimulatorController.getZtreamyErrors(), SimulatorController.getZtreamySends()});
+                LOG.log(Level.SEVERE, "sendEvery10SecondsIfLocationChanged() - Error SEND: Result: {0} - Trama: {1} - Enviada a las: {2} - Errores: {3} / Total: {4}", new Object[]{result, Constants.dfISO8601.format(currentLocationLogDetail.getTimeLog()), Constants.dfISO8601.format(System.currentTimeMillis()), SimulatorController.getZtreamyErrors(), SimulatorController.getZtreamySends()});
+                reconnectPublisher();
             }
         } catch (MalformedURLException ex) {
             LOG.log(Level.SEVERE, "sendEvery10SecondsIfLocationChanged() - Error en la URL", ex);
         } catch (IOException ex) {
             SimulatorController.increaseZtreamyErrors();
             LOG.log(Level.SEVERE, "sendEvery10SecondsIfLocationChanged() - Error I/O: {0} - Trama: {1} - Enviada a las: {2} - Errores: {3} / Total: {4}", new Object[]{ex.getMessage(), Constants.dfISO8601.format(currentLocationLogDetail.getTimeLog()), Constants.dfISO8601.format(System.currentTimeMillis()), SimulatorController.getZtreamyErrors(), SimulatorController.getZtreamySends()});
+            reconnectPublisher();
             // FIXME: ¿Qué hacemos con los que no se hayan podido mandar? ¿Los guardamos y los intentamos enviar después?
         } catch (Exception ex) {
             LOG.log(Level.SEVERE, "sendEvery10SecondsIfLocationChanged() - Error desconocido: {0} - Trama: {1} - Enviada a las: {2} - Errores: {3} / Total: {4}", new Object[]{ex.getMessage(), Constants.dfISO8601.format(currentLocationLogDetail.getTimeLog()), Constants.dfISO8601.format(System.currentTimeMillis()), SimulatorController.getZtreamyErrors(), SimulatorController.getZtreamySends()});
@@ -443,5 +445,16 @@ public class SimulatedSmartDriver extends TimerTask {
         }
 
         return 0.0d;
+    }
+
+    private void reconnectPublisher() {
+        publisher.close();
+        try {
+            this.publisher = new PublisherHC(new URL(URL), new JSONSerializer());
+        } catch (MalformedURLException e) {
+            // No puede pasar, porque habría pasado también en el constructor
+            // y no lo ha hecho.
+        }
+        LOG.log(Level.SEVERE, "Publisher reconnected");
     }
 }

--- a/src/main/java/es/jyago/hermes/simulator/SimulatorController.java
+++ b/src/main/java/es/jyago/hermes/simulator/SimulatorController.java
@@ -59,6 +59,9 @@ public class SimulatorController implements Serializable {
 
     private static final int RR_TIME = 850; // Equivale a una frecuencia cardíaca en reposo media (70 ppm).
 
+    // Máximo retardo para iniciar la ruta, en milisegundos:
+    private static final int MAX_INITIAL_DELAY = 60000;
+
     // Número de errores contabilizados al enviar las tramas a Ztreamy.
     private static volatile int ztreamyErrors;
     // Número de tramas enviadas a Ztreamy
@@ -466,6 +469,7 @@ public class SimulatorController implements Serializable {
             runningThreads = simulatedSmartDrivers * locationLogList.size();
             LOG.log(Level.INFO, "realTimeSimulate() - Se crean: {0} hilos de ejecución", runningThreads);
             try {
+                Random rand = new Random();
                 for (int i = 0; i < locationLogList.size(); i++) {
                     LocationLog ll = locationLogList.get(i);
                     LocationLogDetail smartDriverPosition = ll.getLocationLogDetailList().get(0);
@@ -477,7 +481,7 @@ public class SimulatorController implements Serializable {
                         m.setDraggable(false);
 
                         Timer timer = new Timer();
-                        timer.scheduleAtFixedRate(new SimulatedSmartDriver(ll, m, true, true), 100, 1000);
+                        timer.scheduleAtFixedRate(new SimulatedSmartDriver(ll, m, true, true), 100 + rand.nextInt(MAX_INITIAL_DELAY), 1000);
                         simulationTimers.put(i + "_" + j, timer);
 
                         simulatedMapModel.addOverlay(m);


### PR DESCRIPTION
Cambios:
- Se crea un nuevo objeto PublisherHC cuando falla el envío de un evento. De esta forma se fuerza a establecer una nueva conexión con el servidor de Ztreamy.
- Los conductores inician la ruta desincronizados, con un retardo aleatorio cada uno de entre 0 y 60s.
